### PR TITLE
Configure internal and external listeners for Kafka cluster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
     image: debezium/kafka:1.8
     ports:
       - "9092:9092"
+      - "9090:9090"
     depends_on:
       - zookeeper
     environment:
       ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:9090
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:9090
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
   connect:
     image: debezium/connect:1.8
     ports:


### PR DESCRIPTION
Allows us to interact with the Kafka cluster from outside the Docker Compose network on local machine.

If you have the Kafka CLI tools (`brew install kafka` will make them  available), you can talk to the cluster by specifying the bootstrap server with the correct port for the `EXTERNAL` listener. E.g.:

```bash
kafka-topics --list --bootstrap-server localhost:9090
kafka-console-consumer --bootstrap-server localhost:9090 --topic app.public.users --from-beginning
```